### PR TITLE
PLATY-517: Adjust load to 12 jps

### DIFF
--- a/src/test/resources/journeys.conf
+++ b/src/test/resources/journeys.conf
@@ -4,7 +4,7 @@ journeys {
     description = "Upscan basic scenario"
     fileSize = 5242880
     pollingTimeoutInSeconds = 60
-    load = 1
+    load = 12
     parts = [
       upscan
     ]


### PR DESCRIPTION
In accordance with predicted number of files per second as per PLATY-517, i.e. 12.