### PR TITLE
PLATUI-629: Enabled sbt-auto-build plugin.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val projectSettings = Seq(
 )
 
 lazy val root = (project in file("."))
-  .enablePlugins(GatlingPlugin, CorePlugin, JvmPlugin, IvyPlugin)
+  .enablePlugins(GatlingPlugin, CorePlugin, JvmPlugin, IvyPlugin, SbtAutoBuildPlugin)
   .settings(projectSettings)
   .settings(showClasspath)
   .settings(scalacOptions ++= scalaOptions)
@@ -19,6 +19,7 @@ lazy val root = (project in file("."))
     retrieveManaged := true,
     initialCommands in console := "import uk.gov.hmrc._",
     parallelExecution in Test := false,
+    testOptions in Test := Seq.empty,
     resolvers := Seq(Resolver.bintrayRepo("hmrc", "releases"))
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,8 @@ lazy val root = (project in file("."))
     retrieveManaged := true,
     initialCommands in console := "import uk.gov.hmrc._",
     parallelExecution in Test := false,
+    // Enabling sbt-auto-build plugin provides DefaultBuildSettings with default `testOptions` from `sbt-settings` plugin.
+    // These testOptions are not compatible with `sbt gatling:test`. So we have to override testOptions here.
     testOptions in Test := Seq.empty,
     resolvers := Seq(Resolver.bintrayRepo("hmrc", "releases"))
   )

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -1,3 +1,17 @@
+# Copyright 2020 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 perftest {
   rampupTime = 1
   constantRateTime = 8

--- a/src/test/resources/gatling.conf
+++ b/src/test/resources/gatling.conf
@@ -1,4 +1,4 @@
-# Copyright 2016 HM Revenue & Customs
+# Copyright 2020 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/resources/journeys.conf
+++ b/src/test/resources/journeys.conf
@@ -1,3 +1,17 @@
+# Copyright 2020 HM Revenue & Customs
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 journeys {
 
   v1-clean-pdf-journey = {

--- a/src/test/scala/uk/gov/hmrc/perftests/ExtraInfoExtractor.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/ExtraInfoExtractor.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.perftests
 
 import io.gatling.commons.stats.KO

--- a/src/test/scala/uk/gov/hmrc/perftests/Simulations.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/Simulations.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.perftests
 
 import uk.gov.hmrc.performance.simulation.PerformanceTestRunner

--- a/src/test/scala/uk/gov/hmrc/perftests/UpscanRequests.scala
+++ b/src/test/scala/uk/gov/hmrc/perftests/UpscanRequests.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package uk.gov.hmrc.perftests
 
 import java.io.InputStream


### PR DESCRIPTION
Enabling sbt-auto-build plugin requires overriding `testOptions in Test` from `defaultSettings` in `sbt-settings`. `testOptions` from `sbt-settings` is not compatible with `gatling:test`